### PR TITLE
Enhancement: Update Waiting Logic to handle Cloudflare

### DIFF
--- a/playwright_captcha/solvers/click/cloudflare/solve_by_click.py
+++ b/playwright_captcha/solvers/click/cloudflare/solve_by_click.py
@@ -87,18 +87,26 @@ async def solve_cloudflare_by_click(
     else:
         raise CaptchaSolvingError(f'Failed to click checkbox after maximum attempts')
 
-    # wait for Cloudflare to process the click
-    await asyncio.sleep(solve_click_delay)
-
     # 5. verify success
     if challenge_type == "turnstile":
-        # for turnstile, check for success element in the cf's iframe or expected content is present
+        # for turnstile, check for the success element in the Cloudflare iframe and that it is visible
         success_elements = await search_shadow_root_elements(framework, iframe, 'div[id="success"]')
-        challenge_solved = bool(success_elements)
+        if success_element := next(iter(success_elements), None):
+            try:
+                await success_element.wait_for_element_state("visible", timeout=solve_click_delay * 1000)
+                challenge_solved = True
+            except TimeoutError as e:
+                challenge_solved = False
+        else:
+            raise CaptchaDetectionError("Cloudflare turnstile success element does not exist on the page.")
     else:
-        # for interstitial, check if challenge is gone or expected content is present
-        cloudflare_detected = await detect_cloudflare_challenge(captcha_container)
-        challenge_solved = not cloudflare_detected
+        # for interstitial, check if the challenge is gone or expected content is present
+        try:
+            await page.wait_for_event("load", timeout=solve_click_delay * 1000)
+            cloudflare_detected = await detect_cloudflare_challenge(captcha_container)
+            challenge_solved = not cloudflare_detected
+        except TimeoutError as e:
+            challenge_solved = False
 
     expected_content_detected = await detect_expected_content(page, captcha_container, expected_content_selector)
     if challenge_solved or expected_content_detected:

--- a/playwright_captcha/solvers/click/cloudflare/solve_by_click.py
+++ b/playwright_captcha/solvers/click/cloudflare/solve_by_click.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 from typing import Optional, Union, Literal
 
-from playwright.async_api import Page, ElementHandle, Frame
+from playwright.async_api import Page, ElementHandle, Frame, TimeoutError as PlaywrightTimeoutError
 
 from playwright_captcha.solvers.click.cloudflare.utils.detection import detect_cloudflare_challenge
 from playwright_captcha.solvers.click.cloudflare.utils.dom_helpers import get_ready_checkbox
@@ -46,14 +46,14 @@ async def solve_cloudflare_by_click(
 
     logger.info(f'Starting Cloudflare {challenge_type} challenge solving by click...')
 
-    # 1. check if Cloudflare challenge is present
+    # 1. Check if a Cloudflare challenge is present
     cloudflare_detected = await detect_cloudflare_challenge(captcha_container, challenge_type)
     expected_content_detected = await detect_expected_content(page, captcha_container, expected_content_selector)
     if not cloudflare_detected or expected_content_detected:
         logger.info('No Cloudflare challenge detected')
         return
 
-    # 2. find Cloudflare iframes
+    # 2. Find Cloudflare iframes
     cf_iframes = await search_shadow_root_iframes(
         framework=framework,
         captcha_container=captcha_container,
@@ -62,7 +62,7 @@ async def solve_cloudflare_by_click(
     if not cf_iframes:
         raise CaptchaDetectionError(f'Cloudflare iframes not found')
 
-    # 3. in all found iframes, search for the valid checkbox input and wait until it's ready to be clicked
+    # 3. In all found iframes, search for the valid checkbox input and wait until it's ready to be clicked
     checkbox_data = await get_ready_checkbox(
         framework=framework,
         iframes=cf_iframes,
@@ -74,7 +74,44 @@ async def solve_cloudflare_by_click(
 
     logger.info('Found checkbox in Cloudflare iframe')
 
-    # 4. click the checkbox
+    # 4. Click the checkbox and validate success
+    if challenge_type == "interstitial":
+        try:
+            async with page.expect_event("load", timeout=solve_click_delay * 1000) as reload_event:
+                await click_checkbox(checkbox, checkbox_click_attempts)
+
+            cloudflare_detected = await detect_cloudflare_challenge(captcha_container)
+            challenge_solved = not cloudflare_detected
+        except PlaywrightTimeoutError as e:
+            logger.error("Page did not load within the alloted time after clicking the button")
+            challenge_solved = False
+
+    elif challenge_type == "turnstile":
+        # Turnstile Success - Check that the `success` element is visible and showing
+        await click_checkbox(checkbox, checkbox_click_attempts)
+        success_elements = await search_shadow_root_elements(framework, iframe, 'div[id="success"]')
+        if success_element := next(iter(success_elements), None):
+            try:
+                await success_element.wait_for_element_state("visible", timeout=solve_click_delay * 1000)
+                challenge_solved = True
+            except PlaywrightTimeoutError as e:
+                challenge_solved = False
+        else:
+            raise CaptchaDetectionError("Cloudflare turnstile success element does not exist on the page.")
+    else:
+        raise CaptchaDetectionError("Unsupported Cloudflare Captcha Type: %s", challenge_type)
+
+    # 6 Validate Success
+    expected_content_detected = await detect_expected_content(page, captcha_container, expected_content_selector)
+    if challenge_solved or expected_content_detected:
+        logger.info('Solved successfully')
+        return
+
+    raise CaptchaSolvingError(
+        'Failed to solve Cloudflare challenge by click: challenge still present or expected content not detected')
+
+
+async def click_checkbox(checkbox: ElementHandle, checkbox_click_attempts: int):
     for checkbox_click_attempt in range(checkbox_click_attempts):
         try:
             await checkbox.click()
@@ -86,32 +123,3 @@ async def solve_cloudflare_by_click(
                 f'Error clicking checkbox ({checkbox_click_attempt + 1}/{checkbox_click_attempts} attempt): {e}')
     else:
         raise CaptchaSolvingError(f'Failed to click checkbox after maximum attempts')
-
-    # 5. verify success
-    if challenge_type == "turnstile":
-        # for turnstile, check for the success element in the Cloudflare iframe and that it is visible
-        success_elements = await search_shadow_root_elements(framework, iframe, 'div[id="success"]')
-        if success_element := next(iter(success_elements), None):
-            try:
-                await success_element.wait_for_element_state("visible", timeout=solve_click_delay * 1000)
-                challenge_solved = True
-            except TimeoutError as e:
-                challenge_solved = False
-        else:
-            raise CaptchaDetectionError("Cloudflare turnstile success element does not exist on the page.")
-    else:
-        # for interstitial, check if the challenge is gone or expected content is present
-        try:
-            await page.wait_for_event("load", timeout=solve_click_delay * 1000)
-            cloudflare_detected = await detect_cloudflare_challenge(captcha_container)
-            challenge_solved = not cloudflare_detected
-        except TimeoutError as e:
-            challenge_solved = False
-
-    expected_content_detected = await detect_expected_content(page, captcha_container, expected_content_selector)
-    if challenge_solved or expected_content_detected:
-        logger.info('Solved successfully')
-        return
-
-    raise CaptchaSolvingError(
-        'Failed to solve Cloudflare challenge by click: challenge still present or expected content not detected')

--- a/playwright_captcha/solvers/click/common/shadow_root.py
+++ b/playwright_captcha/solvers/click/common/shadow_root.py
@@ -1,7 +1,9 @@
+import asyncio
 import logging
+from asyncio import Task, CancelledError
 from typing import Union, List, Optional
 
-from playwright.async_api import ElementHandle, Page, Frame
+from playwright.async_api import ElementHandle, Page, Frame, TimeoutError as PlaywrightTimeoutError
 
 from playwright_captcha.types import FrameworkType
 
@@ -71,7 +73,8 @@ async def get_shadow_roots(
 async def search_shadow_root_elements(
         framework: FrameworkType,
         queryable: Union[Page, Frame, ElementHandle],
-        selector: str
+        selector: str,
+        timeout: float = 10
 ) -> List[ElementHandle]:
     """
     Search for elements by selector within the shadow DOM of the queryable object
@@ -79,6 +82,7 @@ async def search_shadow_root_elements(
     :param framework: Framework type (e.g. PATCHRIGHT, CAMOUFOX, PLAYWRIGHT)
     :param queryable: Page, Frame, ElementHandle
     :param selector: CSS selector to search for elements
+    :param timeout: Timeout value in seconds to wait for selector to appear (Default: 10)
 
     :return: List of ElementHandles that match the selector
     """
@@ -86,25 +90,43 @@ async def search_shadow_root_elements(
     logger.debug(f'Searching for elements by selector "{selector}" in {queryable}')
 
     elements = []
-
+    tasks: set[Task] = set()
     try:
         shadow_roots = await get_shadow_roots(framework, queryable)  # get all shadow roots in the queryable object
         for shadow_root in shadow_roots:
             # find all elements by selector within the shadow root
-            js_script = f"shadow => shadow.querySelector('{selector}')"
+            tasks.add(
+                asyncio.create_task(shadow_root.wait_for_selector(selector, timeout=timeout * 1000))
+            )
 
-            element_handle = await shadow_root.evaluate_handle(js_script)
-            if not element_handle:
+        while tasks:
+            completed_tasks, tasks = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+            for task in completed_tasks:
+                try:
+                    if element_handle := task.result():
+                        if element := element_handle.as_element():
+                            elements.append(element)
+                            break
+                except PlaywrightTimeoutError:
+                    logger.debug("Searching shadow root for selector (%s) timed out", selector)
+                except CancelledError:
+                    continue
+            else:
+                # If we don't break the for loop - we havent found an element - continue the loop
                 continue
+            # We only hit this if we break because we found the turnstile - closing the while loop early
+            break
 
-            element = element_handle.as_element()
-            if element:
-                elements.append(element)
     except Exception as e:
         logger.error(f'Error searching for elements: {e}')
 
-    logger.debug(f'Found {len(elements)} elements matching selector "{selector}"')
+    finally:
+        if tasks:
+            for task in tasks:
+                task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
 
+    logger.debug(f'Found {len(elements)} elements matching selector "{selector}"')
     return elements
 
 


### PR DESCRIPTION
# Overview
Currently the code waits an arbitrary amount of time (default: `6 seconds`) and then re-check for the success criteria. This slows down the solving process if the page or turnstile returns more quickly then that.

Changing the logic to wait for an event that should allow it to check sooner based on when we get a response.

Not sure if we want to update/change the variable from the `solve_click_delay` to something that is more accurate on its description - `solve_success_timeout` possibly?

## Cloudflare - Turnstile

This had a bug in it where it would always return as successful as the `success` element is technically always there - it is just hidden.

```python
        success_elements = await search_shadow_root_elements(framework, iframe, 'div[id="success"]')
        challenge_solved = bool(success_elements)
``` 

Changing the logic to grab that element and wait for it to become visible. The original checkbox disappears completely from the DOM - so there could be a check to see if it is there:

```python
    await checkbox.wait_for_element_state("hidden", timeout=solve_click_delay * 1000)
```

## Cloudflare - Challenge Page
Change this to wait for a new `load` event - so when the page re-directs it will then evaluate if the action was successful.

The `on("load")` event triggers when the event next fires - so it will only happen if a **_new_** event fires (and doesn't check the current page state)